### PR TITLE
streamsForCollectionId isn't an array

### DIFF
--- a/src/javascripts/stream.js
+++ b/src/javascripts/stream.js
@@ -280,8 +280,8 @@ function Stream (collectionId, config) {
 		callbacks = null;
 		lastEventId = null;
 
-		if (streamsForCollectionId.indexOf(collectionId) !== -1) {
-			streamsForCollectionId.splice(streamsForCollectionId.indexOf(collectionId), 1);
+		if (typeof streamsForCollectionId[collectionId] !== 'undefined') {
+			streamsForCollectionId[collectionId] = undefined;
 		}
 
 		destroyed = true;


### PR DESCRIPTION
This is causing `TypeError: streamsForCollectionId.indexOf is not a function` when calling `destroy` on an o-comments Widget.
