### PR TITLE
Remove version from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "o-comment-api",
-  "version": "1.1.5",
   "main": "main.js",
   "dependencies": {
     "o-comment-utilities": "^2.0.0"


### PR DESCRIPTION
### [Origami Modules - Packaging and build configuration](http://origami.ft.com/docs/component-spec/modules/#packaging-and-build-configuration)

> Must not include a version property. The version property is not needed and risks being out of sync with the repo tag
